### PR TITLE
Added ability to run test server on any free port. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.5</version>
+			<version>4.12</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/src/main/java/co/wds/testingtools/FunctionalTestRunningRule.java
+++ b/src/main/java/co/wds/testingtools/FunctionalTestRunningRule.java
@@ -1,0 +1,55 @@
+package co.wds.testingtools;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import co.wds.testingtools.annotations.MapperServlet;
+import co.wds.testingtools.annotations.MapperServlet.RespondTo;
+
+/*
+ * Looks like Custom TestRunner doesn't work with Play 2.2-Java and TestRule does.
+ * Just put an instance of this rule into a class:
+ *  @Rule
+ *  public FunctionalTestRunningRule functionalRule = new FunctionalTestRunningRule();
+ *
+ *  Do not mix it with MapperServletTestRunner
+ */
+public class FunctionalTestRunningRule extends TestWatcher {
+    private void addMapping(MapperServlet.RespondTo respondTo) {
+        if (respondTo != null) {
+            addMapping(respondTo.value());
+        }
+    }
+
+    private void addMapping(MapperServlet.ResponseData ... entries) {
+        if (entries != null) {
+            for (MapperServlet.ResponseData entry : entries) {
+                if (entry != null) {
+                    MapperServlet.addNewMapping(entry);
+                }
+            }
+        }
+    }
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                MapperServlet.startMapperServlet(description.getTestClass());
+                try {
+                    addMapping(description.getTestClass().getAnnotation(MapperServlet.ResponseData.class));
+                    addMapping(description.getTestClass().getAnnotation(RespondTo.class));
+                    addMapping(description.getAnnotation(MapperServlet.ResponseData.class));
+                    addMapping(description.getAnnotation(RespondTo.class));
+                    
+                    base.evaluate();
+                } finally {
+                    MapperServlet.stopMapperServlet();
+                }
+            }
+        };
+    }
+
+}

--- a/src/main/java/co/wds/testingtools/annotations/MapperServlet.java
+++ b/src/main/java/co/wds/testingtools/annotations/MapperServlet.java
@@ -54,9 +54,15 @@ public class MapperServlet {
 		}
 	}
 	
+	public static int getPort() {
+	    return mapperServletInstance.server.port;
+	}
+
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
 	public @interface TestServlet {
+	    int ANY_FREE_PORT = -1;
+
 		int port() default 80;
 
 		String contentType() default "application/json";

--- a/src/main/java/co/wds/testingtools/annotations/mapperservlet/TestingServer.java
+++ b/src/main/java/co/wds/testingtools/annotations/mapperservlet/TestingServer.java
@@ -1,5 +1,7 @@
 package co.wds.testingtools.annotations.mapperservlet;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,9 +11,12 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 public class TestingServer {
 
 	ServletContextHandler handler;
+
+    public final int port;
 	
 	public TestingServer(int port) {
-		server = new Server(port);
+	    this.port = port <= 0 ? getFreePort() : port;
+		server = new Server(this.port);
         handler = new ServletContextHandler(ServletContextHandler.SESSIONS);
         handler.setContextPath("/"); // technically not required, as "/" is the default
         server.setHandler(handler);
@@ -20,6 +25,24 @@ public class TestingServer {
 	private Server server;
 
 	private List<String> sessionStartRequests = new ArrayList<String>();
+
+    protected static int getFreePort() {
+        ServerSocket s = null;
+        try {
+            s = new ServerSocket(0);
+            return s.getLocalPort();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (s != null) {
+                try {
+                    s.close();
+                } catch (IOException e1) {
+                    throw new RuntimeException(e1);
+                }
+            }
+        }
+    }
 
 	public void start() throws Exception {
 		server.start();

--- a/src/test/java/co/wds/testingtools/AbstractRunnerTest.java
+++ b/src/test/java/co/wds/testingtools/AbstractRunnerTest.java
@@ -1,0 +1,44 @@
+package co.wds.testingtools;
+
+import static co.wds.testingtools.annotations.MapperServlet.TestServlet.ANY_FREE_PORT;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.Test;
+
+import co.wds.testingtools.annotations.MapperServlet;
+import co.wds.testingtools.annotations.MapperServlet.RespondTo;
+import co.wds.testingtools.annotations.MapperServlet.ResponseData;
+import co.wds.testingtools.annotations.MapperServlet.TestServlet;
+
+@TestServlet(port=ANY_FREE_PORT)
+@RespondTo({
+    @ResponseData(url="test", resourceFile="test.html")
+})
+abstract public class AbstractRunnerTest {
+    @Test
+    public void shouldResponseToBaseData() throws Exception {
+        testServlet("/test", 200);
+    }
+    
+    @Test
+    public void shouldNotRespondToSomethingNotDefinedInTheHeader() throws Exception {
+        testServlet("/hamlet", 404); 
+    }
+    
+    @Test
+    @ResponseData(url="hamlet", resourceFile="hamlet.txt")
+    public void shouldRespondToResponseDefinedInTheTestMethodAnnotation() throws Exception {
+        testServlet("/hamlet", 200);
+    }
+    
+    protected void testServlet(String path, int expectedHttpStatusCode) throws Exception {
+        URL url = new URL("http://localhost:" + MapperServlet.getPort() + path);
+        HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+        connection.setRequestMethod("GET");
+        assertThat(connection.getResponseCode(), is(expectedHttpStatusCode));
+    }
+}

--- a/src/test/java/co/wds/testingtools/FunctionalTestRunningRuleTest.java
+++ b/src/test/java/co/wds/testingtools/FunctionalTestRunningRuleTest.java
@@ -1,0 +1,8 @@
+package co.wds.testingtools;
+
+import org.junit.Rule;
+
+public class FunctionalTestRunningRuleTest extends AbstractRunnerTest {
+    @Rule
+    public FunctionalTestRunningRule functionalRule = new FunctionalTestRunningRule();
+}

--- a/src/test/java/co/wds/testingtools/MapperServletTestRunnerTest.java
+++ b/src/test/java/co/wds/testingtools/MapperServletTestRunnerTest.java
@@ -1,44 +1,11 @@
 package co.wds.testingtools;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.net.HttpURLConnection;
-import java.net.URL;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import co.wds.testingtools.annotations.MapperServlet.RespondTo;
 import co.wds.testingtools.annotations.MapperServlet.ResponseData;
-import co.wds.testingtools.annotations.MapperServlet.TestServlet;
 
 @RunWith(MapperServletTestRunner.class)
-@TestServlet(port=54321)
-@RespondTo({
-	@ResponseData(url="test", resourceFile="test.html")
-})
-public class MapperServletTestRunnerTest {
-	@Test
-	public void shouldResponseToBaseData() throws Exception {
-		testServlet("http://localhost:54321/test", 200);
-	}
-	
-	@Test
-	public void shouldNotRespondToSomethingNotDefinedInTheHeader() throws Exception {
-		testServlet("http://localhost:54321/hamlet", 404); 
-	}
-	
-	@Test
-	@ResponseData(url="hamlet", resourceFile="hamlet.txt")
-	public void shouldRespondToResponseDefinedInTheTestMethodAnnotation() throws Exception {
-		testServlet("http://localhost:54321/hamlet", 200);
-	}
-	
-	protected void testServlet(String theUrl, int expectedHttpStatusCode) throws Exception {
-		URL url = new URL(theUrl);
-		HttpURLConnection connection = (HttpURLConnection)url.openConnection();
-		connection.setRequestMethod("GET");
-		assertThat(connection.getResponseCode(), is(expectedHttpStatusCode));
-	}
+public class MapperServletTestRunnerTest extends AbstractRunnerTest {
 }


### PR DESCRIPTION
Added ability to run test server on any free port to avoid issues with reserving ports
In order to let TestServer take any free port just pass -1 as port in TestServlet annotation:
@TestServlet(port=TestServlet.ANY_FREE_PORT)
Later you can get actual taken port as:
MapperServlet.getPort().

Introduced FunctionalTestRunningRule for starting/stopping test server (for play 2.2 applications where custom test runner doesn't work.